### PR TITLE
Install "patch"

### DIFF
--- a/python3.0/Dockerfile
+++ b/python3.0/Dockerfile
@@ -49,6 +49,7 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
+		patch \
 		pax-utils \
 		readline-dev \
 		readline \


### PR DESCRIPTION
Without this the `patch -p1 ...` command fails.  Most likely many of the other Dockerfiles need this change as well.